### PR TITLE
Updates Group to accept prefix

### DIFF
--- a/gorouter.go
+++ b/gorouter.go
@@ -25,7 +25,7 @@ type Router interface {
 
 	NotFound(notFoundFn http.HandlerFunc)
 
-	Group(fn func(r router.Router)) router.Router
+	Group(prefix string, fn func(r router.Router)) router.Router
 }
 
 func NewRouter() Router {

--- a/router/context/context_test.go
+++ b/router/context/context_test.go
@@ -1,6 +1,7 @@
 package context
 
 import (
+	"net/http/httptest"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -24,6 +25,30 @@ func TestContext_InvalidKey(t *testing.T) {
 	value := ctx.Value("test")
 
 	assert.Equal(t, "", value)
+}
+
+func TestInjectIntoRequest(t *testing.T) {
+	routerCtx := &RouterContext{
+		// Initialize RouterContext properties for testing if needed
+	}
+
+	req := httptest.NewRequest("GET", "/", nil)
+	routerCtx.InjectIntoRequest(req)
+
+	// Retrieve the RouterContext from the request's context
+	ctxValue := req.Context().Value(RouterContextKey)
+	injectedCtx, ok := ctxValue.(*RouterContext)
+	if !ok {
+		t.Errorf("Expected RouterContext, got %T", ctxValue)
+	}
+	assert.NotNil(t, injectedCtx)
+	if injectedCtx == nil {
+		t.Error("Injected context is nil")
+	}
+	if injectedCtx != routerCtx {
+		t.Error("Injected context does not match the original context")
+	}
+
 }
 
 func setup() *RouterContext {

--- a/router/router_test.go
+++ b/router/router_test.go
@@ -20,6 +20,14 @@ func TestNewRouter(t *testing.T) {
 	assert.NotNil(t, router.root, "Root should not be nil")
 
 }
+func TestNewRouterWithPrefix(t *testing.T) {
+	router := NewPrefixRouter("/prefix")
+
+	assert.NotNil(t, router, "Router should not be nil")
+	assert.NotNil(t, router.root, "Root should not be nil")
+	assert.Equal(t, "/prefix", router.prefix, "Root should not be nil")
+
+}
 func TestRouter_RegisterSimplePath(t *testing.T) {
 	r := NewRouter()
 	path := "/path"
@@ -35,7 +43,6 @@ func TestRouter_RegisterSimplePath(t *testing.T) {
 	body, _ := io.ReadAll(res.Body)
 	assert.Equal(t, "hello_world", string(body))
 }
-
 func TestRouter_NotFound(t *testing.T) {
 	r := NewRouter()
 	path := "/not-found"
@@ -51,7 +58,6 @@ func TestRouter_NotFound(t *testing.T) {
 	body, _ := io.ReadAll(res.Body)
 	assert.Equal(t, "hello_world", string(body))
 }
-
 func TestRouter_RegisterWithMiddleware(t *testing.T) {
 	r := NewRouter()
 	path := "/path"
@@ -151,6 +157,7 @@ func TestRouter_RegisterMultiplePath(t *testing.T) {
 func TestRouter_Group(t *testing.T) {
 	router := NewRouter()
 	path1 := "/path1"
+	group := "/group"
 	path2 := "/path2"
 	method := func(w http.ResponseWriter, r *http.Request) {
 	}
@@ -162,7 +169,7 @@ func TestRouter_Group(t *testing.T) {
 	}
 	router.Use(fn)
 	router.Register(_const.GET, path1, method)
-	router.Group(func(r Router) {
+	router.Group(group, func(r Router) {
 		r.Use(func(next http.Handler) http.Handler {
 			return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				next.ServeHTTP(w, r)
@@ -177,7 +184,7 @@ func TestRouter_Group(t *testing.T) {
 	res, _ := http.Get(fmt.Sprintf("%s%s", s.URL, path1))
 	body, _ := io.ReadAll(res.Body)
 	assert.Equal(t, "Hello World Middleware 1", string(body))
-	res, _ = http.Get(fmt.Sprintf("%s%s", s.URL, path2))
+	res, _ = http.Get(fmt.Sprintf("%s%s", s.URL, group+path2))
 	body, _ = io.ReadAll(res.Body)
 	assert.Equal(t, "Hello World Middleware 1Hello World Middleware 2", string(body))
 }

--- a/tree/tree_test.go
+++ b/tree/tree_test.go
@@ -201,3 +201,21 @@ func TestIsParam(t *testing.T) {
 	assert.False(t, isParam("test}"), "Should return false for a non-parameter")
 	assert.False(t, isParam("test"), "Should return false for a non-parameter")
 }
+
+func TestTree_Merge(t *testing.T) {
+	tree := CreateTree()
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
+
+	tree.RegisterRoute(_const.GET, "/path/", handler)
+
+	tree.RegisterRoute(_const.GET, "/path/test", handler)
+
+	tree2 := CreateTree()
+
+	tree2.RegisterRoute(_const.GET, "/pathz/", handler)
+
+	tree2.RegisterRoute(_const.GET, "/pathz/test", handler)
+
+	tree.Merge(&tree2)
+
+}


### PR DESCRIPTION
Modifies Group method to accept prefix. Now every Group will share a prefix in path name. Creates a new method to create Router with prefix. Adds prefix attribute in Router